### PR TITLE
Improve conditioning of the Kalman filter design

### DIFF
--- a/10Control/turb2dof_lqg.m
+++ b/10Control/turb2dof_lqg.m
@@ -204,7 +204,7 @@ for k=1:3
    
    if k>1
        % Create LQG. Measurement is pitch rate. Output is \ddot{flap}.
-       [k1,L1,p1]=kalman (ss_t(4,:),diag([1e-8 1e-2]),1e-6);
+       L1 = lqr(ss_t.A', ss_t.C(4,:)', ss_t.B(:,2)*1e-2*ss_t.B(:,2)' + 1e-8*eye(size(ss_t.A)), 1e-6)';
        [Klqr,Slqr,Elqr] = lqr(ss_t(:,1),Q,1);
        A_lqg=[ss_t.A-ss_t.B(:,1)*Klqr ss_t.B(:,1)*Klqr;
               zeros(size(ss_t.A)) ss_t.A-L1*ss_t.C(4,:)];


### PR DESCRIPTION
Add a little process noise to all states in during the Kalman filter design.  This ensures that the process noise covariance matrix is strictly positive definite, which together with the measurement noise covariance being strictly positive definite makes a set of sufficient (but not necessary) conditions for the solution of the Ricatti equation to exist.

Matlab's `lqr` function is used because it allows noise to be added to the states more easily than the `kalman` function. This is allowed because of the duality of LQR and LQE problems.

The numerical values for the covariance are largely unchanged: the measurement noise covariance is kept to 1e-6, the process noise entering the turbulence channel has 1e-2 covariance and now process noise with 1e-8*eye(n) covariance is added to the states.